### PR TITLE
feat: add startup probe, handling long startups

### DIFF
--- a/charts/calcom/templates/deployment.yaml
+++ b/charts/calcom/templates/deployment.yaml
@@ -229,6 +229,13 @@ spec:
             httpGet:
               path: /
               port: http
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 60
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/calcom/templates/deployment.yaml
+++ b/charts/calcom/templates/deployment.yaml
@@ -229,7 +229,7 @@ spec:
             httpGet:
               path: /
               port: http
-          livenessProbe:
+          startupProbe:
             httpGet:
               path: /
               port: http


### PR DESCRIPTION
Add 5 minutes timer for startupProbe, allowing more time to start the app before triggering Kubernetes alerting.
Solving #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a health check mechanism for enhanced application reliability.
	- Configured periodic checks to monitor application health status.

- **Bug Fixes**
	- Improved application stability by implementing a liveness probe to detect unhealthy states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->