### PR TITLE
add CALCOM_TELEMETRY_DISABLED, EMAIL_FROM_NAME optionnal variables

### DIFF
--- a/charts/calcom/templates/deployment.yaml
+++ b/charts/calcom/templates/deployment.yaml
@@ -111,6 +111,8 @@ spec:
               "E2E_TEST_SAML_ADMIN_PASSWORD"
               "EDGE_CONFIG"
               "EMAIL_FROM"
+              "EMAIL_FROM_NAME"
+              "CAL_SIGNATURE_TOKEN"
               "FORMBRICKS_FEEDBACK_SURVEY_ID"
               "GIPHY_API_KEY"
               "GOOGLE_API_CREDENTIALS"


### PR DESCRIPTION
Add missing variables : 
- CALCOM_TELEMETRY_DISABLED (source : https://github.com/calcom/cal.com/issues/15655)
- EMAIL_FROM_NAME

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new environment variables: `EMAIL_FROM_NAME` and `CAL_SIGNATURE_TOKEN` for enhanced configuration options in the deployment.
  
These changes improve the flexibility of application settings related to email management and signature handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->